### PR TITLE
ref: remove unnecessary ENV isntruction

### DIFF
--- a/docker/prod/interface.Dockerfile
+++ b/docker/prod/interface.Dockerfile
@@ -1,7 +1,6 @@
 FROM node:20-alpine AS frontend-builder
 WORKDIR /myapp
 ARG NEXT_PUBLIC_HOST_API=https://marfa.app
-# ENV NEXT_PUBLIC_HOST_API=$NEXT_PUBLIC_HOST_API
 COPY . .
 RUN npm install
 RUN npm run build


### PR DESCRIPTION
This instruction is not needed as the NEXT_PUBLIC_HOST_API is set only during build time.